### PR TITLE
covering super.turn mistakenly

### DIFF
--- a/Reversi/src/main/java/player/ai/SimpleAI.java
+++ b/Reversi/src/main/java/player/ai/SimpleAI.java
@@ -16,8 +16,6 @@ public class SimpleAI extends Player {
         { -50, -70, 10, 15, 15, 10, -70, -50 },
         { 100, -50, 35, 30, 30, 35, -50, 100 },
     };
-
-    private Turn turn;
     
     public SimpleAI(Turn turn) {
         super(turn);


### PR DESCRIPTION
The declaration "private Turn turn" push behind the declaration "protected final Turn turn" in Play class.
Since this Turn object is the one declared in SimpleAI class and the Turn object which was initialize in a SimpleAI constructor is Turn field of Play class, call for stone method of Turn object at line 35 throws NullPointerException.
