### PR TITLE
should not close standart input scanner

### DIFF
--- a/Reversi/src/main/java/player/HumanPlayer.java
+++ b/Reversi/src/main/java/player/HumanPlayer.java
@@ -23,7 +23,6 @@ public class HumanPlayer extends Player {
                 continue;
             }
 
-            scanner.close();
             return new Position(x, y);
         }
     }


### PR DESCRIPTION
An execution of scanner.close closes System.in as well, thus next execution of scanner.nextInt throws NoSuchElementException.
To avoid this situation, just leave scanner open.
